### PR TITLE
Use a more explicit JWT audience

### DIFF
--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ resource "vault_jwt_auth_backend_role" "example" {
   token_max_ttl   = "300"
   token_policies  = [vault_policy.example.name]
   user_claim      = "actor"
-  bound_audiences = ["https://github.com/OWNER"]
+  bound_audiences = ["vault.example.com"]
   bound_claims    = {
     repository = "OWNER/REPO-NAME",
     ref        = "refs/heads/main",

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,9 @@ inputs:
   ssh_role:
     description: Name of the Vault server SSH certificate role to use
     required: true
+  jwt_audience:
+    description: Custom JWT audience. Defaults to the vault_server hostname
+    required: false
 
 outputs:
   cert_path:
@@ -32,10 +35,19 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Determine JWT audience
+      id: determine
+      run: python3 "${{ github.action_path }}/url2fqdn.py"
+      shell: bash
+      env:
+        AUDIENCE: ${{ inputs.jwt_audience }}
+        VAULT_URL: ${{ inputs.vault_server }}
+
     - name: Authenticate towards Vault
       uses: hashicorp/vault-action@v2.4.2
       with:
         method: jwt
+        jwtGithubAudience: ${{ steps.determine.outputs.audience }}
         jwtTtl: 300
         url: ${{ inputs.vault_server }}
         path: ${{ inputs.oidc_backend }}

--- a/action.yaml
+++ b/action.yaml
@@ -33,7 +33,7 @@ runs:
   using: composite
   steps:
     - name: Authenticate towards Vault
-      uses: hashicorp/vault-action@v2.4.1
+      uses: hashicorp/vault-action@v2.4.2
       with:
         method: jwt
         jwtTtl: 300

--- a/url2fqdn.py
+++ b/url2fqdn.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import os
+from urllib.parse import urlparse
+
+
+def main() -> None:
+    aud: str = os.environ["AUDIENCE"].strip()
+
+    if not aud:
+        url: str = os.environ["VAULT_URL"]
+        fqdn: str = urlparse(url).netloc.split(":")[0]
+        aud = fqdn
+
+    print(f"::set-output name=audience::{aud}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
GitHub's default audience `https://github.com/OWNER` isn't very
helpful when a workflow is setup to perform OIDC authentication
against multiple different services. Instead this Action will now use
the Vault server's hostname as its default audience.