### PR TITLE
Use new method to set GitHub Actions outputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,13 +38,15 @@ runs:
     - name: Determine JWT audience
       id: determine
       run: |
+        import os
         from urllib.parse import urlparse
         aud = "${{ inputs.jwt_audience }}".strip()
         if not aud:
             url = "${{ inputs.vault_server }}"
             fqdn = urlparse(url).netloc.split(":")[0]
             aud = fqdn
-        print(f"::set-output name=audience::{aud}")
+        with open(os.environ["GITHUB_OUTPUT"], "a") as ghof:
+            ghof.write(f"audience={aud}\n")
       shell: python
 
     - name: Authenticate towards Vault

--- a/generate-and-sign
+++ b/generate-and-sign
@@ -34,5 +34,5 @@ outputs=$(mktemp --tmpdir="$RUNNER_TEMP" --directory ssh-cert-XXX)
 install --mode=0644 "$certfile" "$outputs"
 install --mode=0600 "$keyfile" "$outputs"
 
-echo "::set-output name=cert_path::${outputs}/${certfile}"
-echo "::set-output name=key_path::${outputs}/${keyfile}"
+echo "cert_path=${outputs}/${certfile}" >> "$GITHUB_OUTPUT"
+echo "key_path=${outputs}/${keyfile}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
GitHub will be deprecating the `::set-output ...` stdout command.

See also https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/