### PR TITLE
Bump `hashicorp/vault-action` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
       - name: Generate SSH client certificate
         if: github.ref == 'refs/heads/main'
         id: ssh_cert
-        uses: andreaso/vault-oidc-ssh-cert-action@v0.4
+        uses: andreaso/vault-oidc-ssh-cert-action@v0.5
         with:
           vault_server: https://vault.example.com:8200
           oidc_backend: github-oidc

--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ runs:
       shell: python
 
     - name: Authenticate towards Vault
-      uses: hashicorp/vault-action@v2.4.2
+      uses: hashicorp/vault-action@v2.4.3
       with:
         method: jwt
         jwtGithubAudience: ${{ steps.determine.outputs.audience }}


### PR DESCRIPTION
Primarily about it using the new NodeJS 16 runtime.

See also https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.