### PR TITLE
Don't leak (revoked) VAULT_TOKEN environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
       - name: Generate SSH client certificate
         if: github.ref == 'refs/heads/main'
         id: ssh_cert
-        uses: andreaso/vault-oidc-ssh-cert-action@v0.6
+        uses: andreaso/vault-oidc-ssh-cert-action@v0.7
         with:
           vault_server: https://vault.example.com:8200
           oidc_backend: github-oidc

--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ runs:
       shell: python
 
     - name: Authenticate towards Vault
-      uses: hashicorp/vault-action@v2.5.0
+      uses: hashicorp/vault-action@v2.7.0
       with:
         method: jwt
         jwtGithubAudience: ${{ steps.determine.outputs.audience }}

--- a/action.yaml
+++ b/action.yaml
@@ -50,6 +50,7 @@ runs:
       shell: python
 
     - name: Authenticate towards Vault
+      id: vault_auth
       uses: hashicorp/vault-action@v2.7.0
       with:
         method: jwt
@@ -58,7 +59,7 @@ runs:
         url: ${{ inputs.vault_server }}
         path: ${{ inputs.oidc_backend }}
         role: ${{ inputs.oidc_role }}
-        exportToken: true
+        outputToken: true
 
     - name: Generate and sign SSH client certificate
       id: generator
@@ -66,6 +67,7 @@ runs:
       run: ${{ github.action_path }}/generate-and-sign
       env:
         VAULT_SERVER: ${{ inputs.vault_server }}
+        VAULT_TOKEN: ${{ steps.vault_auth.outputs.vault_token }}
         SSH_BACKEND: ${{ inputs.ssh_backend }}
         SSH_ROLE: ${{ inputs.ssh_role }}
         RUNNER_TEMP: ${{ runner.temp }}
@@ -73,5 +75,4 @@ runs:
     - name: Revoke Vault token
       shell: bash
       run: |
-        curl --fail --silent --show-error --header "X-Vault-Token: $VAULT_TOKEN" --data "" "${{ inputs.vault_server }}/v1/auth/token/revoke-self"
-        echo "VAULT_TOKEN=revoked" >> "$GITHUB_ENV"
+        curl --fail --silent --show-error --header "X-Vault-Token: ${{ steps.vault_auth.outputs.vault_token }}" --data "" "${{ inputs.vault_server }}/v1/auth/token/revoke-self"


### PR DESCRIPTION
Made possible by [hashicorp/vault-action][1] now making its token available as an _output_.

[1]: https://github.com/hashicorp/vault-action