### PR TITLE
Bump `hashicorp/vault-action` to version 2.7.1

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -51,7 +51,7 @@ runs:
 
     - name: Authenticate towards Vault
       id: vault_auth
-      uses: hashicorp/vault-action@v2.7.0
+      uses: hashicorp/vault-action@v2.7.1
       with:
         method: jwt
         jwtGithubAudience: ${{ steps.determine.outputs.audience }}


### PR DESCRIPTION
No real need. Mostly about keeping things up-to-date, etc.