### PR TITLE
Ensure Vault token revoke despite cert issuing failure

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -73,5 +73,6 @@ runs:
         RUNNER_TEMP: ${{ runner.temp }}
 
     - name: Revoke Vault token
+      if: success() || failure()
       shell: bash
       run: 'curl --fail --silent --show-error --header "X-Vault-Token: ${{ steps.vault_auth.outputs.vault_token }}" --data "" "${{ inputs.vault_server }}/v1/auth/token/revoke-self"'

--- a/action.yaml
+++ b/action.yaml
@@ -74,5 +74,4 @@ runs:
 
     - name: Revoke Vault token
       shell: bash
-      run: |
-        curl --fail --silent --show-error --header "X-Vault-Token: ${{ steps.vault_auth.outputs.vault_token }}" --data "" "${{ inputs.vault_server }}/v1/auth/token/revoke-self"
+      run: 'curl --fail --silent --show-error --header "X-Vault-Token: ${{ steps.vault_auth.outputs.vault_token }}" --data "" "${{ inputs.vault_server }}/v1/auth/token/revoke-self"'


### PR DESCRIPTION
Opted to not use the [always()][1] expression, being a bit more hesitant to continue an explicitly canceled job.

[1]: https://docs.github.com/en/actions/learn-github-actions/expressions#always