### PR TITLE
Update `hashicorp/vault-action` to version 2.7.4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -54,7 +54,7 @@ runs:
 
     - name: Authenticate towards Vault
       id: vault_auth
-      uses: hashicorp/vault-action@v2.7.1
+      uses: hashicorp/vault-action@v2.7.4
       with:
         method: jwt
         jwtGithubAudience: ${{ steps.determine.outputs.audience }}


### PR DESCRIPTION
No real need. Mostly about keeping things up-to-date, etc.