### PR TITLE
Drop `hashicorp/vault-action` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This action uses [GitHub's OIDC support][1] to authenticate towards a
 HashiCorp Vault instance, and to request a (short-lived) SSH client
 certificate from it.
 
-Under the hood the [hashicorp/vault-action][2] action is used to do
-the actual OIDC authentication.
-
 
 ## Example Usage
 
@@ -113,4 +110,3 @@ resource "vault_jwt_auth_backend_role" "example" {
 
 
 [1]: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
-[2]: https://github.com/hashicorp/vault-action

--- a/action.yaml
+++ b/action.yaml
@@ -52,17 +52,16 @@ runs:
         JWT_AUDIENCE: ${{ inputs.jwt_audience }}
         VAULT_SERVER: ${{ inputs.vault_server }}
 
-    - name: Authenticate towards Vault
+    - name: Use GitHub OIDC to authenticate towards Vault
       id: vault_auth
-      uses: hashicorp/vault-action@v2.7.4
-      with:
-        method: jwt
-        jwtGithubAudience: ${{ steps.determine.outputs.audience }}
-        jwtTtl: 300
-        url: ${{ inputs.vault_server }}
-        path: ${{ inputs.oidc_backend }}
-        role: ${{ inputs.oidc_role }}
-        outputToken: true
+      shell: bash
+      run: "${ACTION_PATH}/github-vault-auth"
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        AUDIENCE: ${{ steps.determine.outputs.audience }}
+        BACKEND: ${{ inputs.oidc_backend }}
+        ROLE: ${{ inputs.oidc_role }}
+        VAULT_SERVER: ${{ inputs.vault_server }}
 
     - name: Generate and sign SSH client certificate
       id: generator

--- a/action.yaml
+++ b/action.yaml
@@ -79,7 +79,7 @@ runs:
       if: success() || steps.generator.conclusion == 'failure'
       shell: bash
       run: |
-        curl --fail --silent --show-error --header "X-Vault-Token: ${VAULT_TOKEN}" --data "" "${VAULT_SERVER}/v1/auth/token/revoke-self"
+        curl --fail --silent --show-error --header "X-Vault-Token: ${VAULT_TOKEN}" --data "" "${VAULT_SERVER%/}/v1/auth/token/revoke-self"
       env:
         VAULT_SERVER: ${{ inputs.vault_server }}
         VAULT_TOKEN: ${{ steps.vault_auth.outputs.vault_token }}

--- a/generate-and-sign
+++ b/generate-and-sign
@@ -16,7 +16,7 @@ cd "$workdir"
 ssh-keygen -q -t ed25519 -N '' -f "./${keyfile}"
 pubkey=$(cat "$pubfile")
 
-vault_server_url="${VAULT_SERVER}/v1/${SSH_BACKEND}/sign/${SSH_ROLE}"
+vault_server_url="${VAULT_SERVER%/}/v1/${SSH_BACKEND}/sign/${SSH_ROLE}"
 
 curl \
     --fail \

--- a/github-vault-auth
+++ b/github-vault-auth
@@ -26,7 +26,7 @@ curl \
     --connect-timeout 10 \
     --output "$vault_response" \
     --data '{"jwt": "'"$github_jwt"'", "role": "'"$ROLE"'"}' \
-    "${VAULT_SERVER}/v1/auth/${BACKEND}/login"
+    "${VAULT_SERVER%/}/v1/auth/${BACKEND}/login"
 
 vault_token=$(jq --exit-status --raw-output .auth.client_token "$vault_response")
 echo "::add-mask::$vault_token"

--- a/github-vault-auth
+++ b/github-vault-auth
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o noglob
+set -o pipefail
+
+github_response=$(mktemp)
+vault_response=$(mktemp)
+trap 'rm "$github_response" "$vault_response"' EXIT
+
+curl \
+    --fail \
+    --silent \
+    --show-error \
+    --connect-timeout 10 \
+    --output "$github_response" \
+    --header "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${AUDIENCE}"
+
+github_jwt=$(jq --exit-status --raw-output .value "$github_response")
+
+curl \
+    --fail \
+    --silent \
+    --show-error \
+    --connect-timeout 10 \
+    --output "$vault_response" \
+    --data '{"jwt": "'"$github_jwt"'", "role": "'"$ROLE"'"}' \
+    "${VAULT_SERVER}/v1/auth/${BACKEND}/login"
+
+vault_token=$(jq --exit-status --raw-output .auth.client_token "$vault_response")
+echo "::add-mask::$vault_token"
+echo "vault_token=$vault_token" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
We only need a fraction of the functionality present in that code.