### PR TITLE
Enforce supported TLS versions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -79,7 +79,7 @@ runs:
       if: success() || steps.generator.conclusion == 'failure'
       shell: bash
       run: |
-        curl --fail --silent --show-error --header "X-Vault-Token: ${VAULT_TOKEN}" --data "" "${VAULT_SERVER%/}/v1/auth/token/revoke-self"
+        curl --fail --silent --show-error --tlsv1.3 --header "X-Vault-Token: ${VAULT_TOKEN}" --data "" "${VAULT_SERVER%/}/v1/auth/token/revoke-self"
       env:
         VAULT_SERVER: ${{ inputs.vault_server }}
         VAULT_TOKEN: ${{ steps.vault_auth.outputs.vault_token }}

--- a/generate-and-sign
+++ b/generate-and-sign
@@ -22,6 +22,7 @@ curl \
     --fail \
     --silent \
     --show-error \
+    --tlsv1.3 \
     --output "$response" \
     --header "X-Vault-Token: $VAULT_TOKEN" \
     --data "{\"public_key\": \"$pubkey\"}" \

--- a/github-vault-auth
+++ b/github-vault-auth
@@ -12,6 +12,7 @@ curl \
     --fail \
     --silent \
     --show-error \
+    --tlsv1.2 \
     --connect-timeout 10 \
     --output "$github_response" \
     --header "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
@@ -23,6 +24,7 @@ curl \
     --fail \
     --silent \
     --show-error \
+    --tlsv1.3 \
     --connect-timeout 10 \
     --output "$vault_response" \
     --data '{"jwt": "'"$github_jwt"'", "role": "'"$ROLE"'"}' \


### PR DESCRIPTION
* https://api.github.com/ supports TLS version 1.3. Likewise can be assumed of any reasonably up-to-date Vault server.
* GitHub's `ACTIONS_ID_TOKEN_REQUEST_URL` endpoint appear to still only support TLS version 1.2.

Do note that these curl options only enforces a minium version. Newer TLS versions will still be allowed and preferred.