### PR TITLE
Rename Vault backend inputs

### DIFF
--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -34,9 +34,9 @@ jobs:
         uses: ./
         with:
           vault_server: https://vault.arrakis.se:8200
-          oidc_backend: github-oidc
+          oidc_backend_path: github-oidc
           oidc_role: cert-action-user
-          ssh_backend: arrakis/ssh2
+          ssh_backend_path: arrakis/ssh2
           ssh_role: cert-action-cert
 
       - name: Examine generated certificate
@@ -48,9 +48,9 @@ jobs:
         with:
           vault_server: https://vault.arrakis.se:8200
           jwt_audience: a-test-audience
-          oidc_backend: github-oidc
+          oidc_backend_path: github-oidc
           oidc_role: cert-action-at-user
-          ssh_backend: arrakis/ssh2
+          ssh_backend_path: arrakis/ssh2
           ssh_role: cert-action-at-cert
 
       - name: Examine second generated certificate

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ jobs:
       - name: Generate SSH client certificate
         if: github.ref == 'refs/heads/main'
         id: ssh_cert
-        uses: andreaso/vault-oidc-ssh-cert-action@v0.9
+        uses: andreaso/vault-oidc-ssh-cert-action@v0.10
         with:
           vault_server: https://vault.example.com:8200
-          oidc_backend: github-oidc
+          oidc_backend_path: github-oidc
           oidc_role: example-user
-          ssh_backend: ssh-client-ca
+          ssh_backend_path: ssh-client-ca
           ssh_role: github-actions-example
 
       - name: Deploy site

--- a/action.yaml
+++ b/action.yaml
@@ -8,13 +8,13 @@ inputs:
   vault_server:
     description: URL of the Vault server
     required: true
-  oidc_backend:
+  oidc_backend_path:
     description: Path to Vault's GitHub configured JWT/OIDC backend
     required: true
   oidc_role:
     description: Name of the Vault server OIDC role to use
     required: true
-  ssh_backend:
+  ssh_backend_path:
     description: Path to Vault's SSH CA backend
     required: true
   ssh_role:
@@ -59,7 +59,7 @@ runs:
       env:
         ACTION_PATH: ${{ github.action_path }}
         AUDIENCE: ${{ steps.determine.outputs.audience }}
-        BACKEND: ${{ inputs.oidc_backend }}
+        BACKEND: ${{ inputs.oidc_backend_path }}
         ROLE: ${{ inputs.oidc_role }}
         VAULT_SERVER: ${{ inputs.vault_server }}
 
@@ -71,7 +71,7 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         VAULT_SERVER: ${{ inputs.vault_server }}
         VAULT_TOKEN: ${{ steps.vault_auth.outputs.vault_token }}
-        SSH_BACKEND: ${{ inputs.ssh_backend }}
+        SSH_BACKEND: ${{ inputs.ssh_backend_path }}
         SSH_ROLE: ${{ inputs.ssh_role }}
         TMPDIR: ${{ runner.temp }}
 


### PR DESCRIPTION
Having the word _path_ in the input names feels more in line with other tooling.

Yes, this is a breaking change.