### PR TITLE
Drop actionlint Ubuntu 24.04 workaround

### DIFF
--- a/.github/linters/actionlint.yaml
+++ b/.github/linters/actionlint.yaml
@@ -1,5 +1,0 @@
----
-
-self-hosted-runner:
-  labels:
-    - ubuntu-24.04


### PR DESCRIPTION
The Super-Linter now contains an Ubuntu 24.04 aware actionlint version.