### PR TITLE
Drop support for Ubuntu 20.04

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
 

--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
 

--- a/vault_oidc_ssh_cert_action.py
+++ b/vault_oidc_ssh_cert_action.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import tempfile
 import urllib.parse
-from typing import List, Tuple
 
 import requests
 
@@ -36,7 +35,7 @@ def _check_inputs() -> None:
         "ssh_role",
         "vault_server",
     ]
-    missing_inputs: List[str] = []
+    missing_inputs: list[str] = []
     for input in required_inputs:
         if not os.environ.get(input.upper(), "").strip():
             missing_inputs.append(input)
@@ -140,7 +139,7 @@ def _issue_ssh_cert(
 
 def _generate_and_sign(
     vault_server: str, vault_token: str, ssh_backend: str, ssh_role: str
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     key_fname = "id_github"
     cert_fname = f"{key_fname}-cert.pub"
 


### PR DESCRIPTION
GitHub will soonish close down their _ubuntu-20.04_ runners

Without the Ubuntu 20.04 Python 3.8 there is no longer any need for the special typing handling of lists and tuples.