### PR TITLE
Ensure Vault token revoke despite cert issuing failure

### DIFF
--- a/vault_oidc_ssh_cert_action.py
+++ b/vault_oidc_ssh_cert_action.py
@@ -201,13 +201,15 @@ def run() -> None:
         vault_server, oidc_backend, oidc_role, jwt_token
     )
 
-    cert_path: str
-    key_path: str
-    cert_path, key_path = _generate_and_sign(
-        vault_server, vault_token, ssh_backend, ssh_role
-    )
+    try:
+        cert_path: str
+        key_path: str
+        cert_path, key_path = _generate_and_sign(
+            vault_server, vault_token, ssh_backend, ssh_role
+        )
 
-    _set_step_output("cert_path", cert_path)
-    _set_step_output("key_path", key_path)
+        _set_step_output("cert_path", cert_path)
+        _set_step_output("key_path", key_path)
 
-    _revoke_token(vault_server, vault_token)
+    finally:
+        _revoke_token(vault_server, vault_token)


### PR DESCRIPTION
If there's a no-longer-needed token, we should attempt to revoke it.

Yes, this had already been added (#13, #19), before it got lost in the Python re-implementation (#28).