### PR TITLE
Rename JWT OIDC inputs

### DIFF
--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -51,8 +51,8 @@ jobs:
         uses: ./
         with:
           vault_server: http://127.0.0.1:8200
-          oidc_backend_path: github-oidc
-          oidc_role: cert-action-user
+          jwt_oidc_backend_path: github-oidc
+          jwt_oidc_role: cert-action-user
           ssh_backend_path: arrakis/ssh2
           ssh_role: cert-action-cert
 
@@ -65,8 +65,8 @@ jobs:
         with:
           vault_server: http://127.0.0.1:8200
           jwt_audience: a-test-audience
-          oidc_backend_path: github-oidc
-          oidc_role: cert-action-at-user
+          jwt_oidc_backend_path: github-oidc
+          jwt_oidc_role: cert-action-at-user
           ssh_backend_path: arrakis/ssh2
           ssh_role: cert-action-cert
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ jobs:
       - name: Generate SSH client certificate
         if: github.ref == 'refs/heads/main'
         id: ssh_cert
-        uses: andreaso/vault-oidc-ssh-cert-action@v0.11
+        uses: andreaso/vault-oidc-ssh-cert-action@v0.12
         with:
           vault_server: https://vault.example.com:8200
           jwt_audience: vault.example.com
-          oidc_backend_path: github-oidc
-          oidc_role: example-user
+          jwt_oidc_backend_path: github-oidc
+          jwt_oidc_role: example-user
           ssh_backend_path: ssh-client-ca
           ssh_role: github-actions-example
 

--- a/action.yaml
+++ b/action.yaml
@@ -8,11 +8,11 @@ inputs:
   vault_server:
     description: URL of the Vault server
     required: true
-  oidc_backend_path:
-    description: Path to Vault's GitHub configured JWT/OIDC backend
+  jwt_oidc_backend_path:
+    description: Path to Vault's GitHub configured JWT OIDC backend
     required: true
-  oidc_role:
-    description: Name of the Vault server OIDC role to use
+  jwt_oidc_role:
+    description: Name of the Vault server JWT OIDC role to use
     required: true
   ssh_backend_path:
     description: Path to Vault's SSH CA backend
@@ -44,8 +44,8 @@ runs:
       env:
         PYTHONPATH: ${{ github.action_path }}
         JWT_AUDIENCE: ${{ inputs.jwt_audience }}
-        OIDC_BACKEND_PATH: ${{ inputs.oidc_backend_path }}
-        OIDC_ROLE: ${{ inputs.oidc_role }}
+        JWT_OIDC_BACKEND_PATH: ${{ inputs.jwt_oidc_backend_path }}
+        JWT_OIDC_ROLE: ${{ inputs.jwt_oidc_role }}
         SSH_BACKEND_PATH: ${{ inputs.ssh_backend_path }}
         SSH_ROLE: ${{ inputs.ssh_role }}
         VAULT_SERVER: ${{ inputs.vault_server }}

--- a/vault_oidc_ssh_cert_action.py
+++ b/vault_oidc_ssh_cert_action.py
@@ -29,8 +29,8 @@ def _set_step_output(name: str, value: str) -> None:
 
 def _check_inputs() -> None:
     required_inputs = [
-        "oidc_backend_path",
-        "oidc_role",
+        "jwt_oidc_backend_path",
+        "jwt_oidc_role",
         "ssh_backend_path",
         "ssh_role",
         "vault_server",
@@ -98,10 +98,10 @@ def _issue_github_jwt(jwt_aud: str) -> str:
 
 
 def _issue_vault_token(
-    vault_server: str, oidc_backend: str, oidc_role: str, jwt_token: str
+    vault_server: str, oidc_backend: str, jwt_oidc_role: str, jwt_token: str
 ) -> str:
     login_url = f"{vault_server}/v1/auth/{oidc_backend}/login"
-    payload = {"jwt": jwt_token, "role": oidc_role}
+    payload = {"jwt": jwt_token, "role": jwt_oidc_role}
 
     try:
         response = requests.post(login_url, data=payload, timeout=10)
@@ -189,8 +189,8 @@ def run() -> None:
     _check_inputs()
 
     input_audience = os.environ["JWT_AUDIENCE"].strip()
-    oidc_role = os.environ["OIDC_ROLE"].strip()
-    oidc_backend = os.environ["OIDC_BACKEND_PATH"].strip("/ ")
+    jwt_oidc_role = os.environ["JWT_OIDC_ROLE"].strip()
+    oidc_backend = os.environ["JWT_OIDC_BACKEND_PATH"].strip("/ ")
     ssh_role = os.environ["SSH_ROLE"].strip()
     ssh_backend = os.environ["SSH_BACKEND_PATH"].strip("/ ")
     vault_server = os.environ["VAULT_SERVER"].strip("/ ")
@@ -198,7 +198,7 @@ def run() -> None:
     jwt_aud: str = _determine_audience(input_audience, vault_server)
     jwt_token: str = _issue_github_jwt(jwt_aud)
     vault_token: str = _issue_vault_token(
-        vault_server, oidc_backend, oidc_role, jwt_token
+        vault_server, oidc_backend, jwt_oidc_role, jwt_token
     )
 
     try:


### PR DESCRIPTION
Having the names include both JWT and OIDC is probably the most correct, since we aren't talking about the full OAuth2 OIDC, but rather JWT tokens relying on OIDC Discovery.

It's likely also the most helpful, since it maps both towards the Vault configuration focusing on the JWT as well as the corresponding GitHub documentation focusing on the OIDC.