### PR TITLE
Drop mention of release immutability

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,21 +145,5 @@ github-deploy@example.com
 ```
 
 
-## Immutable releases
-
-As of version `v2.0` all further releases are intended to take
-advantage of GitHub's [Immutable releases][3].
-
-To verify that a new version tag is indeed immutable you can either
-check the [Releases][4] page for the `Immutable` marker or you can use
-the GitHub CLI to check the tag's release attestation.
-
-```shell
-gh release verify --repo andreaso/vault-oidc-ssh-cert-action v2.0
-```
-
-
 [1]: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
 [2]: https://openbao.org/
-[3]: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases
-[4]: https://github.com/andreaso/vault-oidc-ssh-cert-action/releases


### PR DESCRIPTION
Turns out that `andreaso/vault-oidc-ssh-cert-action@v2.0` isn't as immutable as I first imagined.

Immutable releases and their corresponding tags are purposely deletable, with the limitation that you can't create a new tag nor a new release based on that same tag name. Except that there's nothing stopping me from creating a samely named branch.

Hence a GitHub Actions version `@v2.0` based on an immutable release tag can at any point instead end up being based on a mutable branch.

This reverts #50.