### PR TITLE
Include `ssh -o CertificateFile` in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ jobs:
       - name: Deploy site
         if: github.ref == 'refs/heads/main'
         run: >
-          rsync -e "ssh -i '$SSH_KEY_PATH'"
+          rsync -e "ssh -o IdentityFile='$SSH_KEY_PATH' -o CertificateFile='$SSH_CERT_PATH'"
           --verbose --recursive --delete-after --perms --chmod=D755,F644
           build/ deployer@site.example.net:/var/www/site/
         env:
+          SSH_CERT_PATH: ${{ steps.ssh_cert.outputs.cert_path }}
           SSH_KEY_PATH: ${{ steps.ssh_cert.outputs.key_path }}
 ```
 


### PR DESCRIPTION
Technically not needed as long as the certificate filename is constructed with a `-cert.pub` suffix, which it is in this Action.

Yet being explicit about the certificate filename has the indirect benefit of _ssh_ going directly for the certificate, rather than first attempting and failing on using the regular public key.