### PR TITLE
Stop running Python linting from multiple Ubuntu images

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -16,15 +16,7 @@ permissions:
 jobs:
   python:
     name: Python
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
In hindsight I'm not sure that I see any real value in it. Especially not when there's an integration test running from all the different Ubuntu runner images.