### PR TITLE
Remove no-longer-needed custom zizmor config

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,9 +1,0 @@
----
-
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "actions/*": ref-pin
-        "andreaso/*": ref-pin
-        "*": hash-pin


### PR DESCRIPTION
Allowing select Actions to be to unpinned hasn't been needed since #60.