### PR TITLE
Start running self-test also from Ubuntu 26.04 images

### DIFF
--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -28,6 +28,8 @@ jobs:
           - ubuntu-22.04-arm
           - ubuntu-24.04
           - ubuntu-24.04-arm
+          - ubuntu-26.04
+          - ubuntu-26.04-arm
         include:
           - backend: bao
             os: ubuntu-24.04


### PR DESCRIPTION
By now the Ubuntu 26.04 runner images have been in public preview for a couple of months. Might as well start running the self-test from them as well.

See also https://github.com/actions/runner-images/issues/14226.